### PR TITLE
Optional new mesh algorithm: easyMesh4openEMS by Mustafa Alchalabi

### DIFF
--- a/more_examples/easyMesh/openEMS_generic_nport_MA.py
+++ b/more_examples/easyMesh/openEMS_generic_nport_MA.py
@@ -1,0 +1,185 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules')))
+
+import modules.util_stackup_reader as stackup_reader
+import modules.util_gds_reader as gds_reader
+import modules.util_utilities as utilities
+import modules.util_simulation_setup as simulation_setup
+
+from openEMS import openEMS
+import numpy as np
+
+# Model comments
+# 
+# This is a generic model running port excitation for all ports defined below, 
+# to get full [S] matrix data.
+# Output is stored to Touchstone S-parameter file. 
+# No data plots are created by this script.
+#
+# This model uses an alternative syntax where are settings are stored in settings dictionary,
+# which makes it easier to implement future extensions without touching again the 
+# simulation model code
+
+# Mesh method is set to easyMesh
+# https://github.com/MustafaAlchalabi/easyMesh4openEMS/tree/main
+
+
+# ======================== workflow settings ================================
+settings = {}
+
+settings['preview_only'] = True  # preview model/mesh only?
+settings['postprocess_only'] = False # postprocess existing data without re-running simulation?
+settings['no_gui'] = False # if set to True, there is no mesh/model preview in AppCSXCAD, and simulation starts immediately. 
+
+# ===================== input files and path settings =======================
+
+gds_filename = "line_simple_viaport.gds"   # geometries
+cellname = ""  # optional, set empty string "" to use top cell 
+
+XML_filename = "SG13G2_nosub.xml"          # stackup
+
+# which GDSII data type is evaluated? Values in [] can be separated by comma
+settings['purpose'] = [0]
+
+# preprocess GDSII for safe handling of cutouts/holes?
+settings['preprocess_gds'] = False
+
+# merge via polygons with distance less than .. microns, set to 0 to disable via merging.
+settings['merge_polygon_size'] = 0
+
+
+# get path for this simulation file
+script_path = utilities.get_script_path(__file__)
+# use script filename as model basename
+model_basename = utilities.get_basename(__file__)
+# set and create directory for simulation output
+sim_path = utilities.create_sim_path (script_path,model_basename)
+print('Simulation data directory: ', sim_path)
+
+# change current path to model script path
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+# ======================== simulation settings ================================
+
+
+settings['unit']   = 1e-6  # geometry is in microns
+settings['margin'] = 50    # distance in microns from GDSII geometry boundary to simulation boundary 
+
+settings['fstart']  = 0e9
+settings['fstop']   = 110e9
+settings['numfreq']   = 401
+
+settings['refined_cellsize'] = 2  # mesh cell size in conductor region
+settings['easyMesh'] = True # enable to use easyMesh4openEMS meshing module, https://github.com/MustafaAlchalabi/easyMesh4openEMS/tree/main
+
+# choices for boundary: 
+# 'PEC' : perfect electric conductor (default)
+# 'PMC' : perfect magnetic conductor, useful for symmetries
+# 'MUR' : simple MUR absorbing boundary conditions
+# 'PML_8' : PML absorbing boundary conditions
+settings['Boundaries'] = ['PEC', 'PEC', 'PEC', 'PEC', 'PEC', 'PEC']
+
+settings['cells_per_wavelength'] = 20   # how many mesh cells per wavelength, must be 10 or more
+settings['energy_limit'] = -40          # end criteria for residual energy (dB)
+
+# port configuration, port geometry is read from GDSII file on the specified layer
+simulation_ports = simulation_setup.all_simulation_ports()
+
+# in-plane port is specified with target_layername= and direction x or y
+# via port is specified with from_layername= and to_layername= and direction z
+simulation_ports.add_port(simulation_setup.simulation_port(portnumber=1, 
+                                                           voltage=1, 
+                                                           port_Z0=50, 
+                                                           source_layernum=201, 
+                                                           from_layername='Metal1', 
+                                                           to_layername='TopMetal2', 
+                                                           direction='z'))
+
+simulation_ports.add_port(simulation_setup.simulation_port(portnumber=2, 
+                                                           voltage=1, 
+                                                           port_Z0=50, 
+                                                           source_layernum=202, 
+                                                           from_layername='Metal1', 
+                                                           to_layername='TopMetal2', 
+                                                           direction='z'))
+
+# ======================== simulation ================================
+
+# get technology stackup data
+materials_list, dielectrics_list, metals_list = stackup_reader.read_substrate (XML_filename)
+# get list of layers from technology
+layernumbers = metals_list.getlayernumbers()
+# we must also read the layers where we added ports, these are not included in technology layers
+layernumbers.extend(simulation_ports.portlayers)
+
+# read geometries from GDSII, only purpose 0
+allpolygons = gds_reader.read_gds(gds_filename, 
+                                  layernumbers, 
+                                  purposelist = settings['purpose'], 
+                                  metals_list = metals_list, 
+                                  preprocess  = settings['preprocess_gds'], 
+                                  merge_polygon_size = settings['merge_polygon_size'],
+                                  cellname=cellname)
+
+
+########### create model, run and post-process ###########
+
+settings['simulation_ports'] = simulation_ports
+settings['materials_list'] = materials_list
+settings['dielectrics_list'] = dielectrics_list
+settings['metals_list'] = metals_list
+settings['layernumbers'] = layernumbers
+settings['allpolygons'] = allpolygons
+settings['sim_path'] = sim_path
+settings['model_basename'] = model_basename
+
+
+# maximum cellsize is calculated inside setupSimulation when using settings dictionary
+# wavelength_air = 3e8/fstop / unit
+# max_cellsize = (wavelength_air)/(np.sqrt(materials_list.eps_max)*cells_per_wavelength) 
+
+# define excitation and stop criteria and boundaries
+FDTD = openEMS(EndCriteria=np.exp(settings['energy_limit']/10 * np.log(10)))
+FDTD.SetGaussExcite( (settings['fstart']+settings['fstop'])/2, (settings['fstop']-settings['fstart'])/2 )
+FDTD.SetBoundaryCond( settings['Boundaries'] )
+
+
+########### create model, run and post-process ###########
+
+# run all port excitations, one after another
+for port in simulation_ports.ports:
+    settings['excite_portnumbers'] = [port.portnumber]
+
+    # prepare model from GDSII data
+    simulation_setup.setupSimulation (FDTD=FDTD, settings=settings)  # must use named parameters when using settings dict!
+
+    # Optional: you can work on FDTD and CSX and mesh here using native openEMS commands
+    # CSX = FDTD.GetCSX()   # this already includes geometries from allpolygons data structure processed in setupSimulation()
+    # mesh = CSX.GetGrid()  # this already includes mesh lines from automatic meshing done in setupSimulation()     
+
+    # preview model and start simulation 
+    simulation_setup.runSimulation   (FDTD=FDTD, settings=settings  )# must use named parameters when using settings dict!
+
+
+if not settings['preview_only']:
+
+    # Initialize an empty matrix for S-parameters
+    num_ports = simulation_ports.portcount
+    s_params = np.empty((num_ports, num_ports, settings['numfreq']), dtype=object)
+
+    # Define frequency resolution. Due to FFT from Empire time domain results, 
+    # this is postprocessing and we can change it again at any time.
+    f = np.linspace(settings['fstart'],settings['fstop'],settings['numfreq'])
+
+    # Populate the S-parameter matrix with simulation results
+    for i in range(1, num_ports + 1):
+        for j in range(1, num_ports + 1):
+            s_params[i-1, j-1] = utilities.calculate_Sij(i, j, f, sim_path, simulation_ports)
+
+    # Write to Touchstone *.snp file
+    snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
+    utilities.write_snp(s_params, f, snp_name)
+
+    print('Created S-parameter output file at ', snp_name)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,4 +2,10 @@ These scripts support the workflow when using openEMS.
 
 **deembed_openEMS.py** is a script to deembed parasitic inductance of ports by cascading negative series L at each port. Output is written to a new file with suffix "_deembedded". 
 
-The value of parasitic port inductance is calculated from port geometry, using thin sheet approximation. To do so, this script requires geometry information data created by the latest openEMS workflow version, located in the same directory as the EM simulation result file. This is an experimental feature.
+Usage:
+
+`
+python3 deembed_openEMS.py inputfile.s2p
+`
+
+The value of parasitic port inductance is calculated from port geometry, using thin sheet approximation. To do so, this script requires geometry information data created by the latest openEMS workflow version, located in the same directory as the EM simulation result file. There is not limit on the number of ports. This is an experimental feature.

--- a/workflow/modules/__init__.py
+++ b/workflow/modules/__init__.py
@@ -1,4 +1,4 @@
-# Utilities for gds2openEMS
+# Utilities for gds2openEMS 
 ########################################################################
 #
 # Copyright 2025 Volker Muehlhaus and IHP PDK Authors
@@ -23,5 +23,5 @@ from . import util_utilities as utilities
 from . import util_simulation_setup as simulation_setup
 from . import util_meshlines as util_meshlines
 
-__version__ = "0.1.1"   # version of gds2openEMS
+__version__ = "0.2.1"   # version of gds2openEMS
 

--- a/workflow/modules/util_meshlines.py
+++ b/workflow/modules/util_meshlines.py
@@ -449,6 +449,55 @@ def create_xy_mesh_from_polygons (mesh, allpolygons, margin, antenna_margin, tar
     # done
     return mesh
 
+
+# ------------------- Mesh using autoMesh module -------------------------
+
+def create_xy_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna_margin, target_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings):
+    
+    # load easyMesh module
+    from easyMesh import GenerateMesh
+
+    # configure easyMesh
+    global_mesh_setup = {
+        'drawing_unit': settings['unit'],  # geometry is in microns
+        'start_frequency': settings['fstart'],
+        'stop_frequency': settings['fstop'],
+        'mesh_resolution': settings.get('mesh_resolution','medium'), # 'low', 'medium', 'high', 'very_high'
+        'use_circle_detection': settings.get('use_circle_detection', False), 
+        'boundary_distance': settings.get('boundary_distance', [None, None, None, None, None, None]), # value, 'auto' or None
+        'handle_closely_placed_edges': settings.get('handle_closely_placed_edges', True),  # if True, then mesher will try to handle close placed edges by merging them
+        'min_cellsize': settings.get('refined_cellsize', 1),
+        'dirs': 'xy'
+    }
+
+    GenerateMesh(CSX, global_mesh_setup, primitives_mesh_setup, properties_mesh_setup)
+    mesh = CSX.GetGrid()
+    return mesh
+
+
+
+def create_z_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna_margin, target_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings):
+    
+    # load easyMesh module
+    from easyMesh import GenerateMesh
+
+    # configure easyMesh
+    global_mesh_setup = {
+        'drawing_unit': settings['unit'],  # geometry is in microns
+        'start_frequency': settings['fstart'],
+        'stop_frequency': settings['fstop'],
+        'mesh_resolution': settings.get('mesh_resolution','medium'), # 'low', 'medium', 'high', 'very_high'
+        'use_circle_detection': settings.get('use_circle_detection', False), 
+        'boundary_distance': settings.get('boundary_distance', [None, None, None, None, None, None]), # value, 'auto' or None
+        'handle_closely_placed_edges': settings.get('handle_closely_placed_edges', True),  # if True, then mesher will try to handle close placed edges by merging them
+        'min_cellsize': 0.1,  # for stackup in z direction
+        'dirs': 'z'
+    }
+
+    GenerateMesh(CSX, global_mesh_setup, primitives_mesh_setup, properties_mesh_setup)
+    mesh = CSX.GetGrid()
+    return mesh
+
 # ------------------- internal utilities -------------------------
 
 

--- a/workflow/modules/util_meshlines.py
+++ b/workflow/modules/util_meshlines.py
@@ -452,7 +452,7 @@ def create_xy_mesh_from_polygons (mesh, allpolygons, margin, antenna_margin, tar
 
 # ------------------- Mesh using autoMesh module -------------------------
 
-def create_xy_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna_margin, target_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings):
+def create_xy_using_easyMesh(CSX, allpolygons, simulation_ports, margin, antenna_margin, target_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings):
     
     # load easyMesh module
     from easyMesh import GenerateMesh

--- a/workflow/modules/util_meshlines.py
+++ b/workflow/modules/util_meshlines.py
@@ -457,7 +457,7 @@ def create_xy_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna
     # load easyMesh module
     from easyMesh import GenerateMesh
 
-    # configure easyMesh
+    # configure easyMesh for xyz direction (no separate call for z direction!)
     global_mesh_setup = {
         'drawing_unit': settings['unit'],  # geometry is in microns
         'start_frequency': settings['fstart'],
@@ -467,36 +467,14 @@ def create_xy_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna
         'boundary_distance': settings.get('boundary_distance', [None, None, None, None, None, None]), # value, 'auto' or None
         'handle_closely_placed_edges': settings.get('handle_closely_placed_edges', True),  # if True, then mesher will try to handle close placed edges by merging them
         'min_cellsize': settings.get('refined_cellsize', 1),
-        'dirs': 'xy'
+        'dirs': 'xyz'
     }
 
     GenerateMesh(CSX, global_mesh_setup, primitives_mesh_setup, properties_mesh_setup)
     mesh = CSX.GetGrid()
     return mesh
 
-
-
-def create_z_using_autoMesh(CSX, allpolygons, simulation_ports, margin, antenna_margin, target_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings):
-    
-    # load easyMesh module
-    from easyMesh import GenerateMesh
-
-    # configure easyMesh
-    global_mesh_setup = {
-        'drawing_unit': settings['unit'],  # geometry is in microns
-        'start_frequency': settings['fstart'],
-        'stop_frequency': settings['fstop'],
-        'mesh_resolution': settings.get('mesh_resolution','medium'), # 'low', 'medium', 'high', 'very_high'
-        'use_circle_detection': settings.get('use_circle_detection', False), 
-        'boundary_distance': settings.get('boundary_distance', [None, None, None, None, None, None]), # value, 'auto' or None
-        'handle_closely_placed_edges': settings.get('handle_closely_placed_edges', True),  # if True, then mesher will try to handle close placed edges by merging them
-        'min_cellsize': 0.1,  # for stackup in z direction
-        'dirs': 'z'
-    }
-
-    GenerateMesh(CSX, global_mesh_setup, primitives_mesh_setup, properties_mesh_setup)
-    mesh = CSX.GetGrid()
-    return mesh
+# no need for separate z mesh function, that is all done in create_xyz_using_autoMesh
 
 # ------------------- internal utilities -------------------------
 

--- a/workflow/modules/util_simulation_setup.py
+++ b/workflow/modules/util_simulation_setup.py
@@ -593,16 +593,17 @@ def setupSimulation (excite_portnumbers=None,
     FDTD.SetCSX(CSX)
 
     # check if easyMesh is enabled
-    if settings.get('easyMesh', False):
-        # load easyMesh module
-        from easyMesh import enhance_csx_for_auto_mesh, enhance_FDTD_for_auto_mesh
-        # configure easyMesh
-        primitives_mesh_setup = {}
-        properties_mesh_setup = {}
-        CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
-        FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
-        xy_mesh_function=util_meshlines.create_xy_using_autoMesh
-        z_mesh_function=util_meshlines.create_z_using_autoMesh
+    if settings is not None:
+        if settings.get('easyMesh', False):
+            # load easyMesh module
+            from easyMesh import enhance_csx_for_auto_mesh, enhance_FDTD_for_auto_mesh
+            # configure easyMesh
+            primitives_mesh_setup = {}
+            properties_mesh_setup = {}
+            CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
+            FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
+            xy_mesh_function=util_meshlines.create_xy_using_autoMesh
+            z_mesh_function=util_meshlines.create_z_using_autoMesh
 
 
     # add geometries and return list of used materials
@@ -628,7 +629,10 @@ def setupSimulation (excite_portnumbers=None,
             poly.is_via = metal.is_via
 
     # add mesh
-    if settings.get('easyMesh', False):    
+    easyMesh = False
+    if settings is not None:
+        easyMesh = settings.get('easyMesh', False)
+    if easyMesh:        
         mesh = addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function, primitives_mesh_setup=primitives_mesh_setup, properties_mesh_setup=properties_mesh_setup, settings=settings )
     else:    
         mesh = addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function)

--- a/workflow/modules/util_simulation_setup.py
+++ b/workflow/modules/util_simulation_setup.py
@@ -271,8 +271,12 @@ def addGeometry_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials
                             CSX_material.SetColor('#' + material.color, 255)  # transparency value 255 = solid
 
                     # add Polygon to CSX 
-                    # remember value for MA meshing algorithm, which works on CSX polygons rather than our GDS polygons
-                    p = CSX_material.AddLinPoly(priority=200, points=poly.pts, norm_dir ='z', elevation=metal.zmin, length=metal.thickness)
+                    # remember value for optional easyMesh meshing algorithm, which works on CSX polygons rather than our GDS polygons
+                    # use different prio for metal and via here, because easyMesh evaluates that to prioritize closely spaced edges
+                    if metal.is_via:
+                        p = CSX_material.AddLinPoly(priority=50, points=poly.pts, norm_dir ='z', elevation=metal.zmin, length=metal.thickness)
+                    else:    
+                        p = CSX_material.AddLinPoly(priority=200, points=poly.pts, norm_dir ='z', elevation=metal.zmin, length=metal.thickness)
                     poly.CSXpoly = p
 
                 else:
@@ -490,7 +494,7 @@ def addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cel
         mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list)
 
     # mesh using easyMesh module requires extra parameters
-    if xy_mesh_function==util_meshlines.create_xy_using_autoMesh:
+    if xy_mesh_function==util_meshlines.create_xy_using_easyMesh:
         mesh = xy_mesh_function (CSX, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list, primitives_mesh_setup, properties_mesh_setup, settings)
     else:
         mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize)
@@ -601,7 +605,7 @@ def setupSimulation (excite_portnumbers=None,
                 properties_mesh_setup = {}
                 CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
                 FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
-                xy_mesh_function=util_meshlines.create_xy_using_autoMesh
+                xy_mesh_function=util_meshlines.create_xy_using_easyMesh
                 z_mesh_function=None
             except ImportError:
                 # easymesh module not found

--- a/workflow/modules/util_simulation_setup.py
+++ b/workflow/modules/util_simulation_setup.py
@@ -485,16 +485,14 @@ def addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cel
     # meshing of dielectrics and metals
     no_z_mesh_list = [] # exclude from meshing, specify stackup layer name here
 
-    # mesh using autoMesh module requires extra parameters
-    if xy_mesh_function==util_meshlines.create_xy_using_autoMesh:
-        mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list, primitives_mesh_setup, properties_mesh_setup, settings)
-    else:
+    if z_mesh_function is not None:
+        # not used when using easyMesh module, which does xyz meshing all togerther in one call
         mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list)
-        
 
-    if z_mesh_function==util_meshlines.create_z_using_autoMesh:
-        mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings)
-    else:        
+    # mesh using easyMesh module requires extra parameters
+    if xy_mesh_function==util_meshlines.create_xy_using_autoMesh:
+        mesh = xy_mesh_function (CSX, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list, primitives_mesh_setup, properties_mesh_setup, settings)
+    else:
         mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize)
 
     return mesh
@@ -596,15 +594,20 @@ def setupSimulation (excite_portnumbers=None,
     if settings is not None:
         if settings.get('easyMesh', False):
             # load easyMesh module
-            from easyMesh import enhance_csx_for_auto_mesh, enhance_FDTD_for_auto_mesh
-            # configure easyMesh
-            primitives_mesh_setup = {}
-            properties_mesh_setup = {}
-            CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
-            FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
-            xy_mesh_function=util_meshlines.create_xy_using_autoMesh
-            z_mesh_function=util_meshlines.create_z_using_autoMesh
-
+            try: 
+                from easyMesh import enhance_csx_for_auto_mesh, enhance_FDTD_for_auto_mesh
+                # configure easyMesh
+                primitives_mesh_setup = {}
+                properties_mesh_setup = {}
+                CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
+                FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
+                xy_mesh_function=util_meshlines.create_xy_using_autoMesh
+                z_mesh_function=None
+            except ImportError:
+                # easymesh module not found
+                print("\n\nERROR: could not load Python module easyMesh, available at https://github.com/MustafaAlchalabi/easyMesh4openEMS")    
+                print("==> settings['easyMesh']=True is ignored until you install that module!\n\n")
+                settings['easyMesh']=False
 
     # add geometries and return list of used materials
     CSX, CSX_materials_list = addGeometry_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_list, dielectrics_list, metals_list, allpolygons)

--- a/workflow/modules/util_simulation_setup.py
+++ b/workflow/modules/util_simulation_setup.py
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import json
 
 from . import util_utilities as utilities
 from . import util_meshlines
@@ -29,6 +30,9 @@ from openEMS import openEMS
 from openEMS.physical_constants import *
 
 import numpy as np
+
+# global variable for port metadata information
+all_port_information_struct = {}
 
 
 class simulation_port:
@@ -347,6 +351,9 @@ def addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_li
     # hold CSX material definitions, but only for stackup materials that are actually used
     CSX_materials_list = {}
 
+    # data structure that we write to Palace output directory with information about port Z0 and port dimensions
+    all_port_information = []
+
     # add geometries on metal and via layers
     for poly in allpolygons.polygons:
         # each poly knows its layer number
@@ -361,8 +368,15 @@ def addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_li
                 # mark polygon for special handling in meshing
                 poly.is_port = True 
 
+                # information for port metadata file
+                port_information_data = {}
+                port_information_data['portnumber'] = port.portnumber
+                port_information_data['Z0'] = port.port_Z0
+                port_information_data['direction'] = port.direction.upper()
+
+
                 portnum = port.portnumber
-                port_direction = port.direction
+                port_direction = port.direction.lower()
                 port_Z0 = port.port_Z0
                 if portnum in excite_portnumbers: # list of excited ports, this can be more than one port number for GSG with composite ports
                     voltage = port.voltage        # only apply source voltage to ports that are excited in this simulation run
@@ -385,6 +399,16 @@ def addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_li
                     port_metal = metals_list.getbylayername(port.target_layername)
                     zmin = port_metal.zmin
                     zmax = port_metal.zmax
+
+                    if 'X' in port.direction.upper():
+                        length = xmax-xmin
+                        width  = ymax-ymin
+                    else:    
+                        length = ymax-ymin
+                        width  = xmax-xmin
+                    port_information_data['length'] = length                           
+                    port_information_data['width']  = width      
+
                 else:
                     # via port 
                     if port.from_layername == 'GND': # special case bottom of simulation box
@@ -419,25 +443,59 @@ def addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_li
                         zmin = zmax_to
                         zmax = zmin_from
 
+                    # for port metadata of via ports, check if port is wider in x or y direction
+                    size_x = xmax - xmin
+                    size_y = ymax - ymin 
+                    if size_y > size_x:
+                        width = size_y
+                    else: 
+                        width = size_x
+
+                    # for via port, length is size in z direction
+                    length = zmax-zmin
+                    port_information_data['length'] = length                            
+                    port_information_data['width']  = width      
+
+                port_information_data['xmin'] = xmin                           
+                port_information_data['xmax'] = xmax      
+                port_information_data['ymin'] = ymin                           
+                port_information_data['ymax'] = ymax      
+                port_information_data['zmin'] = zmin                           
+                port_information_data['zmax'] = zmax      
+
+                all_port_information.append(port_information_data)
+
+
                 CSX_port = FDTD.AddLumpedPort(portnum, port_Z0, [xmin, ymin, zmin], [xmax, ymax, zmax], port_direction, voltage, priority=150)
                 # store CSX_port in the port object, for evaluation later
                 port.set_CSXport(CSX_port)
                     
-
+        # store port metadata for use by external de-embedding algorithm
+        all_port_information_struct['ports'] = all_port_information
 
     return CSX
 
 
 
-def addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function):
+def addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function, primitives_mesh_setup=None, properties_mesh_setup=None, settings=None):
 # Add mesh using default method
     mesh = CSX.GetGrid()
     mesh.SetDeltaUnit(unit)
 
     # meshing of dielectrics and metals
     no_z_mesh_list = [] # exclude from meshing, specify stackup layer name here
-    mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list)
-    mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize)
+
+    # mesh using autoMesh module requires extra parameters
+    if xy_mesh_function==util_meshlines.create_xy_using_autoMesh:
+        mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list, primitives_mesh_setup, properties_mesh_setup, settings)
+    else:
+        mesh = z_mesh_function (mesh, dielectrics_list, metals_list, refined_cellsize, max_cellsize, air_around, no_z_mesh_list)
+        
+
+    if z_mesh_function==util_meshlines.create_z_using_autoMesh:
+        mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize, primitives_mesh_setup, properties_mesh_setup, settings)
+    else:        
+        mesh = xy_mesh_function (mesh, allpolygons, margin, air_around, refined_cellsize, max_cellsize)
 
     return mesh
 
@@ -478,7 +536,7 @@ def setupSimulation (excite_portnumbers=None,
                      margin=None, 
                      unit=None, 
                      z_mesh_function=util_meshlines.create_z_mesh, 
-                     xy_mesh_function=util_meshlines.create_standard_xy_mesh, 
+                     xy_mesh_function=util_meshlines.create_xy_mesh_from_polygons, 
                      air_around=0, 
                      field_dumps=False,
                      settings=None):
@@ -531,20 +589,35 @@ def setupSimulation (excite_portnumbers=None,
             exit(1)
 
 
-
     CSX = ContinuousStructure()
     FDTD.SetCSX(CSX)
+
+    # check if easyMesh is enabled
+    if settings.get('easyMesh', False):
+        # load easyMesh module
+        from easyMesh import enhance_csx_for_auto_mesh, enhance_FDTD_for_auto_mesh
+        # configure easyMesh
+        primitives_mesh_setup = {}
+        properties_mesh_setup = {}
+        CSX = enhance_csx_for_auto_mesh(CSX, primitives_mesh_setup)
+        FDTD = enhance_FDTD_for_auto_mesh(FDTD, primitives_mesh_setup)        
+        xy_mesh_function=util_meshlines.create_xy_using_autoMesh
+        z_mesh_function=util_meshlines.create_z_using_autoMesh
+
 
     # add geometries and return list of used materials
     CSX, CSX_materials_list = addGeometry_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_list, dielectrics_list, metals_list, allpolygons)
     CSX, CSX_materials_list = addDielectrics_to_CSX (CSX, CSX_materials_list,  materials_list, dielectrics_list, allpolygons, margin, addPEC=False)
 
-    # add ports
-    CSX  = addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_list, dielectrics_list, metals_list, allpolygons)
+    # add ports, return CSX and port metadata for saving to JSON
+    CSX = addPorts_to_CSX (CSX, excite_portnumbers,simulation_ports,FDTD, materials_list, dielectrics_list, metals_list, allpolygons)
 
+    # add units and model name to port information metadata
+    all_port_information_struct['unit'] = unit
+    
     # check which layers are actually used, this information is required for meshing in z direction
     # mark if polygon is a via
-    if metals_list != None: 
+    if metals_list is not None: 
       for poly in allpolygons.polygons:
         layernum = poly.layernum
         metal = metals_list.getbylayernumber(layernum)
@@ -555,9 +628,13 @@ def setupSimulation (excite_portnumbers=None,
             poly.is_via = metal.is_via
 
     # add mesh
-    mesh = addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function )
+    if settings.get('easyMesh', False):    
+        mesh = addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function, primitives_mesh_setup=primitives_mesh_setup, properties_mesh_setup=properties_mesh_setup, settings=settings )
+    else:    
+        mesh = addMesh_to_CSX (CSX, allpolygons, dielectrics_list, metals_list, refined_cellsize, max_cellsize, margin, air_around, unit, z_mesh_function, xy_mesh_function)
 
-    if field_dumps != False:
+
+    if field_dumps is not False:
         addFielddumps_to_CSX (FDTD, CSX, field_dumps, allpolygons, metals_list)
 
     # display mesh information (line count and smallest mesh cells)
@@ -609,8 +686,18 @@ def runSimulation (excite_portnumbers=None,
         postprocess_only = False
 
 
+    # Write JSON with port information to simulation data directory, used for external de-embedding
+    # This might be called multiple times if there are multiple excitations, but never mind ...
+    port_information_file = os.path.join(sim_path, 'port_information.json')
+    print('Creating port information metadata file ', port_information_file)
+    all_port_information_struct['name'] = model_basename 
+    with open(port_information_file, 'w', encoding='utf-8') as f:
+        json.dump(all_port_information_struct, f, ensure_ascii=False, indent=4)
+    f.close()
+
+
     excitation_path = utilities.get_excitation_path (sim_path, excite_portnumbers)
-    
+
     if not postprocess_only:
         # write CSX file 
         CSX_file = os.path.join(excitation_path, model_basename + '.xml')
@@ -622,7 +709,7 @@ def runSimulation (excite_portnumbers=None,
             print('Starting AppCSXCAD 3D viewer with file: \n', CSX_file)
             print('Close AppCSXCAD to continue or press <Ctrl>-C to abort')
 
-            # for Linux, send warningas and errors to nowhere, so that we don't trash console with vtk warnings
+            # for Linux, send warnings and errors to nowhere, so that we don't trash console with vtk warnings
             if os.name == 'posix':
                 suffix = ' 2>/dev/null'
             else:
@@ -632,7 +719,7 @@ def runSimulation (excite_portnumbers=None,
             if ret != 0:
                 print('[ERROR] AppCSXCAD failed to launch. Exit code: ', ret)
                 sys.exit(1)
-
+   
     if not (preview_only or postprocess_only):  # start simulation 
         # Check if we can read a hash file from the result folder
         existing_data_hash = get_hash_from_data_folder(excitation_path)


### PR DESCRIPTION
When using settings[] syntax in model file, the alternative mesh algorithm easyMesh4openEMS can be used
https://github.com/MustafaAlchalabi/easyMesh4openEMS
This is enabled by adding 
`settings['easyMesh']=True`
in the model code. If easyMesh Python module is missing, a message is displayed and the workflow uses standard mesh algorith.
