### PR TITLE
Note that Materials thermal parameters are unused by S-parameter simulation

### DIFF
--- a/doc/XML_stackup_format.md
+++ b/doc/XML_stackup_format.md
@@ -44,6 +44,11 @@ file may use attributes this version of the reader doesn't know about yet.
 One `<Material>` element per material, referenced by name from `<Dielectric>` and `<Layer>`
 elements later in the file.
 
+> **Note:** `Density`, `ThermalConductivity`, and `ThermalConductivityTable` are **not used by
+> S-parameter simulation**. They are only read when this XML file is used in a thermal
+> simulation flow — leaving them at their defaults (or omitting them) has no effect on EM
+> simulation results.
+
 | Attribute                 | Required | Default | Description |
 |----------------------------|----------|---------|--------------|
 | `Name`                     | yes      | —       | Material name, referenced elsewhere as `Material="..."`. |


### PR DESCRIPTION
## Summary
- Adds a visible note in the `<Materials>` section of doc/XML_stackup_format.md: `Density`, `ThermalConductivity`, and `ThermalConductivityTable` are only used by the thermal simulation flow, not S-parameter simulation — to avoid confusion about whether these need to be set for EM runs.